### PR TITLE
fix a mismatch when game starts

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/ConnectionManager.cpp
@@ -345,7 +345,9 @@ void ConnectionManager::destroyGameMessages() {
  * assumption that a command will only be relayed once.
  */
 void ConnectionManager::doRelay() {
-	NetworkLog(ELogVerbosity::LOG_DEBUG, "ConnectionManager::doRelay on execution frame %d", TheNetwork->getExecutionFrame());
+	Int execFrame = TheGameLogic->getFrame() + TheNetwork->getRunAhead();
+	NetworkLog(ELogVerbosity::LOG_DEBUG, "ConnectionManager::doRelay on execution frame %d", execFrame);
+
 	static Int numPackets = 0;
 	static Int numCommands = 0;
 


### PR DESCRIPTION
Network::getExecutionFrame() has side effects which in certain instances can cause mismatch

this temporarily fixes the issue with current codebase. maybe declare it as private?

The mismatch happens for example when TheLAN initiates a MSG_NEW_GAME:
in Normal situation TheNetwork->m_lastExecutionFrame is updated after TheGameLogic has been reset.
in this case it's updated before the reset then further in the execution it causes a mismatch.