### PR TITLE
Add nextRepeatTime and fix key repeat logic and backspace burst deleting characters

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/Keyboard.h
@@ -77,6 +77,7 @@ struct KeyboardIO
 	UnsignedByte	status;									// StatusType, above
 	UnsignedShort	state;									// KEY_STATE_* in KeyDefs.h
 	UnsignedInt		keyDownTimeMsec;				// real-time in milliseconds when key went down
+	UnsignedInt		nextRepeatTimeMsec;     // real-time in milliseconds when key should next repeat
 
 };
 
@@ -88,8 +89,8 @@ class Keyboard : public SubsystemInterface
 
 	enum
 	{
-		KEY_REPEAT_DELAY_MSEC = 333,	// 10 frames at 30 FPS
-		KEY_REPEAT_INTERVAL_MSEC = 67	// ~2 frames at 30 FPS
+		KEY_REPEAT_DELAY_MSEC = 333,
+		KEY_REPEAT_INTERVAL_MSEC = 33
 	};
 
 public:

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/Input/Keyboard.cpp
@@ -144,7 +144,10 @@ void Keyboard::updateKeys( void )
 		// Update key down time for new key presses
 		if( BitIsSet( m_keys[ index ].state, KEY_STATE_DOWN ) )
 		{
-			m_keyStatus[ m_keys[ index ].key ].keyDownTimeMsec = m_keys[ index ].keyDownTimeMsec;
+			const UnsignedInt downTime = m_keys[index].keyDownTimeMsec;
+			m_keyStatus[m_keys[index].key].keyDownTimeMsec = downTime;
+			m_keyStatus[m_keys[index].key].nextRepeatTimeMsec = downTime + Keyboard::KEY_REPEAT_DELAY_MSEC;
+
 		}
 
 		// prevent ALT-TAB from causing a TAB event
@@ -225,26 +228,27 @@ Bool Keyboard::checkKeyRepeat( void )
 		if( BitIsSet( m_keyStatus[ key ].state, KEY_STATE_DOWN ) )
 		{
 
-			const UnsignedInt now = timeGetTime();
-			const UnsignedInt keyDownTime = m_keyStatus[ key ].keyDownTimeMsec;
-			const UnsignedInt elapsedMsec = now - keyDownTime;
+			UnsignedInt now = timeGetTime();
+			UnsignedInt &nextRepeatTime = m_keyStatus[ key ].nextRepeatTimeMsec;
 
-			if( elapsedMsec > Keyboard::KEY_REPEAT_DELAY_MSEC )
+			if(now >= nextRepeatTime)
 			{
 				// Add key to this frame
 				m_keys[ index ].key = (UnsignedByte)key;
-				m_keys[ index ].state = KEY_STATE_DOWN | KEY_STATE_AUTOREPEAT;  // note: not a bitset; this is an assignment
+				m_keys[ index ].state = KEY_STATE_DOWN;
 				m_keys[ index ].status = KeyboardIO::STATUS_UNUSED;
 
-				// Set End Flag
-				m_keys[ ++index ].key = KEY_NONE;
-
 				// Set all keys as new to prevent multiple keys repeating
-				for( index = 0; index< NUM_KEYS; index++ )
-					m_keyStatus[ index ].keyDownTimeMsec = now;
+				for( index = 0; index < NUM_KEYS; ++index )
+				{
+					if (index != key)
+					{
+						m_keyStatus[index].nextRepeatTimeMsec = now + Keyboard::KEY_REPEAT_DELAY_MSEC;
+					}
+				}
 
 				// Set repeated key so it will repeat again after the interval
-				m_keyStatus[ key ].keyDownTimeMsec = now - (Keyboard::KEY_REPEAT_DELAY_MSEC + Keyboard::KEY_REPEAT_INTERVAL_MSEC);
+				nextRepeatTime = now + Keyboard::KEY_REPEAT_INTERVAL_MSEC;
 
 				retVal = TRUE;
 				break;  // exit for key


### PR DESCRIPTION
fixes the issue where pressing/holding `backspace` would delete multiple characters at once. The old logic rewound keyDownTimeMsec into the past which made the repeat check think several intervals had already passed. This PR uses nextRepeatTimeMsec and schedules repeats based on real time.