### PR TITLE
Extend visibility condition in createRadiusDecal() to include observer players

### DIFF
--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -377,7 +377,7 @@ public:
 		m_pos = pos;
 		m_angle = angle;
 		m_pitch = pitch;
-		m_zoom = zoom;
+		m_zoom = std::clamp(zoom, 0.f, 1.f);
 	}
 
 private:

--- a/Core/GameEngine/Source/GameClient/RadiusDecal.cpp
+++ b/Core/GameEngine/Source/GameClient/RadiusDecal.cpp
@@ -66,8 +66,8 @@ void RadiusDecalTemplate::createRadiusDecal(const Coord3D& pos, Real radius, con
 	// it is now considered nonEmpty, regardless of the state of m_decal, etc
 	result.m_empty = false;
 
-	if (!m_onlyVisibleToOwningPlayer ||
-			owningPlayer->getPlayerIndex() == ThePlayerList->getLocalPlayer()->getPlayerIndex())
+	if (!m_onlyVisibleToOwningPlayer || owningPlayer->getPlayerIndex() == ThePlayerList->getLocalPlayer()->getPlayerIndex()
+									 || ThePlayerList->getLocalPlayer()->isPlayerObserver())
 	{
 		Shadow::ShadowTypeInfo decalInfo;
 		decalInfo.allowUpdates = FALSE;										// shadow texture will never update


### PR DESCRIPTION
This change allows observers to see support powers radius decals

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/369cc72a-9fbd-4550-b19e-3005606e30b1" />
