### PR TITLE
Fix crashes when serializing non ascii characters to json

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/GeneralsOnline/json.hpp
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/GeneralsOnline/json.hpp
@@ -21298,7 +21298,7 @@ class basic_json // NOLINT(cppcoreguidelines-special-member-functions,hicpp-spec
     string_t dump(const int indent = -1,
                   const char indent_char = ' ',
                   const bool ensure_ascii = false,
-                  const error_handler_t error_handler = error_handler_t::strict) const
+                  const error_handler_t error_handler = error_handler_t::replace) const
     {
         string_t result;
         serializer s(detail::output_adapter<char, string_t>(result), indent_char, error_handler);


### PR DESCRIPTION
The game crashed when selecting maps or sending messages with non ascii characters in any of the online chats due to nlohmann::json's default error handler being set to `strict`, which throws an exception when serializing invalid UTF-8 bytes. 
Changed the default error handler to `error_handler_t::replace` to prevent the crashes.