### PR TITLE
bugfix(lobby): pass correct lobbySlot arg to DetermineColorForChatMessage

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/OnlineServices_RoomsInterface.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/OnlineServices_RoomsInterface.cpp
@@ -1047,7 +1047,7 @@ void WebSocket::Tick()
 												}
 
 												// no admin chat in lobby
-												Color color = DetermineColorForChatMessage(EChatMessageType::CHAT_MESSAGE_TYPE_LOBBY, true, chatData.action, false, lobbySlot);
+												Color color = DetermineColorForChatMessage(EChatMessageType::CHAT_MESSAGE_TYPE_LOBBY, true, chatData.action, false, false, lobbySlot);
 
 												if (pLobbyInterface->m_OnChatCallback != nullptr)
 												{


### PR DESCRIPTION
Fixes a bug where players chat messages in lobby setup appeared grey instead of their chosen army color due to lobbySlot being passed into the wrong parameter after bIsNameChange was added.

before
<img width="1592" height="276" alt="image" src="https://github.com/user-attachments/assets/99e47190-3ba9-405b-85a7-fe2e6e41d2a7" />

after
<img width="1600" height="280" alt="image" src="https://github.com/user-attachments/assets/e2b7bb76-e5ae-4172-aadf-133eb16ca9ee" />
