### PR TITLE
feat(lobby): Add timestamp prefix to network room chat messages

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/OnlineServices_RoomsInterface.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/OnlineServices_RoomsInterface.cpp
@@ -698,7 +698,11 @@ void WebSocket::Tick()
 
 										if (bParsed)
 										{
-											UnicodeString unicodeStr(from_utf8(chatData.message).c_str());
+											SYSTEMTIME systemTime;
+											GetLocalTime(&systemTime);
+
+											UnicodeString unicodeStr;
+											unicodeStr.format(L"[%2.2d:%2.2d] %s", systemTime.wHour, systemTime.wMinute, from_utf8(chatData.message).c_str());
 
 											Color color = DetermineColorForChatMessage(EChatMessageType::CHAT_MESSAGE_TYPE_NETWORK_ROOM, true, chatData.action, chatData.admin, chatData.name_change);
 


### PR DESCRIPTION
Adds [HH:MM] timestamps to the network lobby chat messages

<img width="901" height="337" alt="image" src="https://github.com/user-attachments/assets/26d8b4d9-649e-4e59-ba0f-a6cfcd47be04" />
