### PR TITLE
tweak(quickmatch): Disable remaining unused army and color dropdowns in QuickMatch setup

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -1089,6 +1089,10 @@ void WOLQuickMatchMenuInit( WindowLayout *layout, void *userData )
 		comboBoxMaxPing->winEnable(FALSE);
 	if (comboBoxMaxDisconnects)
 		comboBoxMaxDisconnects->winEnable(FALSE);
+	if (comboBoxSide)
+		comboBoxSide->winEnable(FALSE);
+	if (comboBoxColor)
+		comboBoxColor->winEnable(FALSE);
 
 	// welcome msg + instructions
 	GadgetListBoxAddEntryText(quickmatchTextWindow, UnicodeString(L"Welcome to QuickMatch. Choose Setup to select playlists and maps."), GameMakeColor(255, 194, 25, 255), -1, -1);


### PR DESCRIPTION
Disable remaining unused dropdowns in QuickMatch setup to avoid confusion

<img width="1049" height="476" alt="image" src="https://github.com/user-attachments/assets/edb640ad-1ecb-4aa1-b44d-781665b5a00f" />
