### PR TITLE
tweak(communicator): Display friend requests above the friends list and sort unread messages to the top

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -583,8 +583,30 @@ void updateBuddyInfo( void )
 				}
 			}
 
-            // FRIENDS
-            int i = 0;
+			// REQUESTS
+			for (auto& kvPair : pSocialInterface->GetCachedRequestsList())
+			{
+				FriendsEntry friendsEntry = kvPair.second;
+				int64_t profileID = friendsEntry.user_id;
+				AsciiString strName = AsciiString(friendsEntry.display_name.c_str());
+
+				// insert name into box
+				UnicodeString formatStr;
+				formatStr.translate(strName.str());
+				int index = GadgetListBoxAddEntryText(buddyControls.listboxBuddies, formatStr, GameSpyColor[GSCOLOR_DEFAULT], -1, -1);
+				GadgetListBoxSetItemData(buddyControls.listboxBuddies, (void*)(profileID), index, 0);
+
+				// insert status into box
+				formatStr = TheGameText->fetch("GUI:BuddyAddReq");
+				GadgetListBoxAddEntryText(buddyControls.listboxBuddies, formatStr, GameSpyColor[GSCOLOR_DEFAULT], index, 1);
+				GadgetListBoxSetItemData(buddyControls.listboxBuddies, (void*)(ITEM_REQUEST), index, 1);
+
+				if (profileID == selectedProfile)
+					selected = index;
+			}
+
+			// FRIENDS
+			int i = 0;
 			auto friendsMap = pSocialInterface->GetCachedFriendsList();
 			std::vector<std::pair<int64_t, FriendsEntry>> sortedFriends(friendsMap.begin(), friendsMap.end());
 			std::stable_sort(sortedFriends.begin(), sortedFriends.end(),
@@ -649,28 +671,6 @@ void updateBuddyInfo( void )
                 GadgetListBoxAddEntryText(buddyControls.listboxBuddies, formatStr, GameSpyColor[GSCOLOR_DEFAULT], index, 1);
                 GadgetListBoxSetItemData(buddyControls.listboxBuddies, (void*)(profileID), index, 0);
                 GadgetListBoxSetItemData(buddyControls.listboxBuddies, (void*)(ITEM_BUDDY), index, 1);
-
-                if (profileID == selectedProfile)
-                    selected = index;
-            }
-
-            // REQUESTS
-            for (auto& kvPair : pSocialInterface->GetCachedRequestsList())
-            {
-                FriendsEntry friendsEntry = kvPair.second;
-                int64_t profileID = friendsEntry.user_id;
-                AsciiString strName = AsciiString(friendsEntry.display_name.c_str());
-
-                // insert name into box
-                UnicodeString formatStr;
-                formatStr.translate(strName.str());
-                int index = GadgetListBoxAddEntryText(buddyControls.listboxBuddies, formatStr, GameSpyColor[GSCOLOR_DEFAULT], -1, -1);
-                GadgetListBoxSetItemData(buddyControls.listboxBuddies, (void*)(profileID), index, 0);
-
-                // insert status into box
-                formatStr = TheGameText->fetch("GUI:BuddyAddReq");
-                GadgetListBoxAddEntryText(buddyControls.listboxBuddies, formatStr, GameSpyColor[GSCOLOR_DEFAULT], index, 1);
-                GadgetListBoxSetItemData(buddyControls.listboxBuddies, (void*)(ITEM_REQUEST), index, 1);
 
                 if (profileID == selectedProfile)
                     selected = index;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -610,7 +610,13 @@ void updateBuddyInfo( void )
 			auto friendsMap = pSocialInterface->GetCachedFriendsList();
 			std::vector<std::pair<int64_t, FriendsEntry>> sortedFriends(friendsMap.begin(), friendsMap.end());
 			std::stable_sort(sortedFriends.begin(), sortedFriends.end(),
-				[](auto& a, auto& b) { return a.second.online > b.second.online; });
+				[&](auto& a, auto& b) {
+					Int unreadA = pSocialInterface->GetNumberUnreadChatMessagesForUser(a.second.user_id);
+					Int unreadB = pSocialInterface->GetNumberUnreadChatMessagesForUser(b.second.user_id);
+					if (unreadA != unreadB)
+						return unreadA > unreadB;
+					return a.second.online > b.second.online;
+				});
 
 			for (auto& kvPair : sortedFriends)
             {


### PR DESCRIPTION
Friend requests were displayed at the bottom of the communicator list, below all friends. This meant that players with a large friends list had to scroll through the entire list to find and act on pending friends requests, and with a full friends list of 100 they would not be visible at all. 
Friend requests are now moved above friends so they are immediately visible to take action on

<img width="798" height="732" alt="image" src="https://github.com/user-attachments/assets/3fea2332-0b8c-4b97-abc9-d7e518638764" />
