### PR TITLE
fix(communicator): Fix exploit revealing quickmatch opponent in lobby setup

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLBuddyOverlay.cpp
@@ -529,8 +529,9 @@ void updateBuddyInfo( void )
 						// dont allow self
 						if (profileID != user_id)
 						{
-							// dont show if already friends
-							if (!pSocialInterface->IsUserFriend(profileID))
+							// dont show if already friends or if in QM lobby
+							bool bIsInQMLobby = !TheNGMPGame->isGameInProgress() && TheNGMPGame->isQMGame();
+							if (!pSocialInterface->IsUserFriend(profileID) && !bIsInQMLobby)
 							{
 								setCurrentGameMembers.insert(profileID);
 


### PR DESCRIPTION
Fixes an exploit where players could identify their quickmatch opponent (and abort) before the game started by checking the buddy overlay for current players.
Current players are now hidden when in the quickmatch lobby.