### PR TITLE
fix(lobby): Prevent crash from buttonBack re-enabling on countdown completion

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -2474,6 +2474,7 @@ void WOLGameSetupMenuUpdate( WindowLayout * layout, void *userData)
 				// are we done?
 				if (secondsRemaining <= 0)
 				{
+					s_matchStartCountdownWasRunning = false;
 					// stop countdown
 					TheNGMPGame->StopCountdown();
 


### PR DESCRIPTION
When the match start countdown reached zero, StopCountdown was called which caused the update loop to detect the countdown had stopped and re enable the back button. Due to network delay, the game start packet had not yet arrived, leaving a window where clicking back caused a crash.

Fixed by setting matchStartCountdownWasRunning to false before StopCountdown so the reenable is skipped when the countdown completes