### PR TITLE
feat(lobby): Add setting to disable alternate colors in lobby list

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
@@ -892,7 +892,10 @@ static Int insertGame(GameWindow* win, LobbyEntry& lobbyInfo, Bool showMap)
 	bool bAlternate = (rowCount % 2 == 0);
 	if (bAlternate && gameColor == GameSpyColor[GSCOLOR_GAME])
 	{
-		gameColor = GameMakeColor(191, 198, 201, 255);
+		if (NGMP_OnlineServicesManager::Settings.LobbyList_AlternateColors())
+		{
+			gameColor = GameMakeColor(191, 198, 201, 255);
+		}
 	}
 	Int index = GadgetListBoxAddEntryText(win, gameName, gameColor, -1, COLUMN_NAME);
 	GadgetListBoxSetItemData(win, (void*)gameID, index);

--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/GeneralsOnline/GeneralsOnline_Settings.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/GeneralsOnline/GeneralsOnline_Settings.h
@@ -39,6 +39,7 @@ public:
 
 	bool Graphics_DrawStatsOverlay() const { return m_Render_DrawStatsOverlay; }
 	bool Graphics_LimitFramerate() const { return m_Render_LimitFramerate; }
+	bool LobbyList_AlternateColors() const { return m_LobbyList_AlternateColors; }
 	int Graphics_GetFPSLimit() const
 	{
 		if (!m_Render_LimitFramerate)
@@ -135,6 +136,8 @@ private:
 	bool m_Social_Notification_PlayerAcceptsRequest_Gameplay = true;
 	bool m_Social_Notification_PlayerSendsRequest_Menus = true;
 	bool m_Social_Notification_PlayerSendsRequest_Gameplay = true;
+
+	bool m_LobbyList_AlternateColors = true;
 
 	EHTTPVersion m_Network_HTTPVersion = EHTTPVersion::HTTP_VERSION_AUTO;
 	bool m_Network_UseAlternativeEndpoint = false;

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/GeneralsOnline_Settings.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/GeneralsOnline_Settings.cpp
@@ -26,6 +26,9 @@
 #define SETTINGS_KEY_SOCIAL_NOTIFICATIONS_PLAYER_SENDS_REQUEST_MENUS "notification_player_sends_request_menus"
 #define SETTINGS_KEY_SOCIAL_NOTIFICATIONS_PLAYER_SENDS_REQUEST_GAMEPLAY "notification_player_sends_request_gameplay"
 
+#define SETTINGS_KEY_LOBBY_LIST "lobby_list"
+#define SETTINGS_KEY_LOBBY_LIST_ALTERNATE_COLORS "alternate_lobby_colors"
+
 #define SETTINGS_KEY_DEBUG "debug"
 #define SETTINGS_KEY_DEBUG_VERBOSE_LOGGING "verbose_logging"
 
@@ -245,6 +248,14 @@ void GenOnlineSettings::Load(void)
                     m_Social_Notification_PlayerSendsRequest_Gameplay = socialSettings[SETTINGS_KEY_SOCIAL_NOTIFICATIONS_PLAYER_SENDS_REQUEST_GAMEPLAY];
                 }
             }
+
+			if (jsonSettings.contains(SETTINGS_KEY_LOBBY_LIST))
+			{
+				auto lobbyListSettings = jsonSettings[SETTINGS_KEY_LOBBY_LIST];
+
+				if (lobbyListSettings.contains(SETTINGS_KEY_LOBBY_LIST_ALTERNATE_COLORS))
+					m_LobbyList_AlternateColors = lobbyListSettings[SETTINGS_KEY_LOBBY_LIST_ALTERNATE_COLORS];
+			}
 		}
 		
 	}
@@ -334,6 +345,13 @@ void GenOnlineSettings::Save()
                     {SETTINGS_KEY_SOCIAL_NOTIFICATIONS_PLAYER_SENDS_REQUEST_GAMEPLAY, m_Social_Notification_PlayerSendsRequest_Gameplay},
                 }
         },
+
+		{
+			SETTINGS_KEY_LOBBY_LIST,
+				{
+					{SETTINGS_KEY_LOBBY_LIST_ALTERNATE_COLORS, m_LobbyList_AlternateColors},
+				}
+		},
     };
 	
 	std::string strData = root.dump(1);


### PR DESCRIPTION
Adds a settings.json option to disable alternating colors in the lobby list.
When disabled, the list will use the default white color instead of alternating between white and grey. 