### PR TITLE
bugfix(quickmatch): Disable the back button when a QuickMatch is found

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -1161,6 +1161,7 @@ void WOLQuickMatchMenuInit( WindowLayout *layout, void *userData )
 
 		pLobbyInterface->RegisterForMatchmakingMatchFoundCallback([]()
 			{
+				buttonBack->winEnable(FALSE);
 				buttonStop->winEnable(FALSE);
                 if (TheAudio)
 				{
@@ -1205,9 +1206,6 @@ void WOLQuickMatchMenuInit( WindowLayout *layout, void *userData )
 				// TODO_NGMP
 				//SendStatsToOtherPlayers(TheNGMPGame);
 
-				// we've started, there's no going back
-				// i.e. disable the back button.
-				buttonBack->winEnable(FALSE);
 				GameWindow* buttonBuddy = TheWindowManager->winGetWindowFromId(NULL, NAMEKEY("GameSpyGameOptionsMenu.wnd:ButtonCommunicator"));
 				if (buttonBuddy)
 					buttonBuddy->winEnable(FALSE);


### PR DESCRIPTION
Prevents various bugs when a player clicked the back button after theyve found a quickmatch