### PR TITLE
bugfix: fix listbox row animation to be frame rate independent and fix animation reliability

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
+++ b/Core/GameEngine/Source/GameNetwork/GameSpy/LobbyUtils.cpp
@@ -44,7 +44,6 @@
 #include "GameClient/GameWindowManager.h"
 #include "GameClient/GadgetComboBox.h"
 #include "GameClient/GadgetListBox.h"
-#include "GameClient/GadgetTextEntry.h"
 #include "GameClient/GameText.h"
 #include "GameClient/MapUtil.h"
 #include "GameClient/MessageBox.h"
@@ -94,38 +93,6 @@ enum {
 	COLUMN_PING,
 };
 #endif
-
-// ---------------------------------------------------------------------------
-// row entry animation
-// ---------------------------------------------------------------------------
-
-static std::map<int, GameRowAnim> g_gameListAnim;
-
-// initialize the smoothed index for this lobbyID
-static float UpdateAndGetGameRowIndex(int lobbyID, float logicalIndex)
-{
-    GameRowAnim& anim = g_gameListAnim[lobbyID];
-
-    if (!anim.alive)
-    {
-        // start slightly below, then glide into place
-        anim.currentIndex = logicalIndex + 2.f;
-        anim.targetIndex  = logicalIndex;
-        anim.alive        = true;
-    }
-    else
-    {
-        anim.targetIndex = logicalIndex;
-    }
-
-    // how fast to snap into place
-    const float t = 0.2f; 
-
-    float delta = anim.targetIndex - anim.currentIndex;
-    anim.currentIndex += delta * t;
-
-    return anim.currentIndex;
-}
 
 static NameKeyType buttonSortAlphaID = NAMEKEY_INVALID;
 static NameKeyType buttonSortPingID = NAMEKEY_INVALID;
@@ -1251,13 +1218,6 @@ void RefreshGameListBox(GameWindow* win, Bool showMap)
 				for (SortedGameList::iterator sglIt = sgl.begin(); sglIt != sgl.end(); ++sglIt)
 				{
 					LobbyEntry lobby = *sglIt;
-
-                    // Logical index for this entry in the new sorted list
-					float logicalIndex = (float)i;
-
-					// register/update animation index for this lobbyID
-					UpdateAndGetGameRowIndex(lobby.lobbyID, logicalIndex);
-
 					Int index = insertGame(win, lobby, showMap);
 					if (lobby.lobbyID == selectedID)
 					{
@@ -1395,45 +1355,6 @@ void RefreshGameInfoListBox( GameWindow *mainWin, GameWindow *win )
 //	}
 
 }
-
-// ---------------------------------------------------------------------------
-// compute pixel offset for a game list row
-// ---------------------------------------------------------------------------
-int GetGameListRowPixelOffsetForRow(GameWindow* window, int rowIndex, int rowHeight)
-{
-	if (!window)
-		return 0;
-
-	// We rely on listbox item data storing lobbyID, like RefreshGameListBox uses
-	Int lobbyID = (Int)GadgetListBoxGetItemData(window, rowIndex);
-	if (lobbyID == 0)
-		return 0;
-
-    GameWindow* mainGameList = GetGameListBox();
-
-    int animKey;
-    if (window == mainGameList)
-    {
-        // For the main game list: use lobbyID
-        animKey = lobbyID;
-    }
-    else
-    {
-        // For all other lists: keep per row key to avoid overlap
-        animKey = lobbyID * 1024 + rowIndex;
-    }
-
-
-	// Get smoothed "visual index" for this lobbyID
-	float visualIndex = UpdateAndGetGameRowIndex(animKey, (float)rowIndex);
-
-	// Offset = (visualIndex - logicalIndex) * rowHeight
-	float offsetRows = visualIndex - (float)rowIndex;
-	int pixelOffset = (int)(offsetRows * (float)rowHeight);
-
-	return pixelOffset;
-}
-
 
 void RefreshGameListBoxes( void )
 {

--- a/GeneralsMD/Code/GameEngine/Include/GameClient/GadgetTextEntry.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameClient/GadgetTextEntry.h
@@ -123,16 +123,3 @@ inline Color GadgetTextEntryGetHiliteBorderColor( GameWindow *g )					{ return g
 
 // EXTERNALS //////////////////////////////////////////////////////////////////
 
-struct GameRowAnim
-{
-	float currentIndex;
-	float targetIndex;
-	bool  alive;
-
-	GameRowAnim()
-		: currentIndex(0.0f)
-		, targetIndex(0.0f)
-		, alive(false)
-	{
-	}
-};

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DListBox.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/GUI/Gadget/W3DListBox.cpp
@@ -56,8 +56,6 @@
 
 // DEFINES ////////////////////////////////////////////////////////////////////
 
-int GetGameListRowPixelOffsetForRow(GameWindow* window, int rowIndex, int rowHeight);
-
 // PRIVATE TYPES //////////////////////////////////////////////////////////////
 
 // PRIVATE DATA ///////////////////////////////////////////////////////////////
@@ -69,6 +67,73 @@ int GetGameListRowPixelOffsetForRow(GameWindow* window, int rowIndex, int rowHei
 ///////////////////////////////////////////////////////////////////////////////
 // PRIVATE FUNCTIONS //////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////
+
+// ApplyListBoxRowAnimation====================================================
+// applies row entry animation offset to drawY.
+// rows slide in from below their target position and settle into place
+//=============================================================================
+struct RowAnimState
+{
+	Real        currentIndex;   // where the row is drawn right now, catches up to targetIndex over time
+	Real        targetIndex;    // where the row actually belongs in the list
+	UnsignedInt lastUpdateTime; // last time this row was drawn, used to detect when a listbox reopens
+	void	   *lastItemData;   // last item data seen in this slot, used to detect when the item changes
+
+	RowAnimState()
+	{
+		currentIndex = 0.f;
+		targetIndex = 0.f;
+		lastUpdateTime = 0;
+		lastItemData = nullptr;
+	}
+};
+
+static std::map<Int, RowAnimState> theRowAnimState;
+static void ApplyListBoxRowAnimation(GameWindow *window, Int rowIndex, Int rowHeight, Int &drawY)
+{
+	if (!window)
+		return;
+
+	// shift window ID to avoid collisions with rowIndex
+	Int rowAnimKey = (window->winGetWindowId() << 16) + rowIndex;
+	RowAnimState &anim = theRowAnimState[rowAnimKey];
+	UnsignedInt now = timeGetTime();
+	Real deltaTime = 0.f;
+
+	if (anim.lastUpdateTime != 0)
+	{
+		UnsignedInt elapsedMs = now - anim.lastUpdateTime;
+
+		// if this row hasn't been drawn for over 60ms, the listbox was closed, reset its state so it re-animates on the next open
+		if (elapsedMs > 60)
+		{
+			anim = RowAnimState();
+		}
+		else
+		{
+			deltaTime = elapsedMs / (Real)MSEC_PER_SECOND;
+		}
+	}
+
+	anim.lastUpdateTime = now;
+	void *itemData = GadgetListBoxGetItemData(window, rowIndex);
+	Real  rowIndexF = (Real)rowIndex;
+
+	// trigger animation when first seen, when the row moves, or when the item in this slot changes
+	if (anim.currentIndex < 0.f || anim.targetIndex != rowIndexF || itemData != anim.lastItemData)
+	{
+		const Real rowAnimStartOffset = 1.f;
+		anim.currentIndex = rowIndexF + rowAnimStartOffset;
+	}
+
+	anim.lastItemData = itemData;
+	anim.targetIndex = rowIndexF;
+
+	const Real snapSpeed = 20.f;
+	anim.currentIndex += (anim.targetIndex - anim.currentIndex) * snapSpeed * deltaTime;
+
+	drawY += (Int)((anim.currentIndex - rowIndexF) * (Real)rowHeight);
+}
 
 // drawHiliteBar ==============================================================
 /** Draw image for the hilite bar */
@@ -197,13 +262,8 @@ static void drawListBoxText( GameWindow *window, WinInstanceData *instData,
 	IRegion2D clipRegion;
 	ICoord2D start, end;
 
-    Color debugBg = TheWindowManager->winMakeColor(3, 93, 166, 20);
-	TheWindowManager->winFillRect(
-		debugBg,
-		WIN_DRAW_LINE_WIDTH,
-		x, y,
-		x + width, y + height
-	);
+    Color WindowBg = TheWindowManager->winMakeColor(3, 93, 166, 20);
+	TheWindowManager->winFillRect(WindowBg, WIN_DRAW_LINE_WIDTH, x, y, x + width, y + height);
 
 	//
 	// save the clipping information region cause we're going to use it here
@@ -244,8 +304,7 @@ static void drawListBoxText( GameWindow *window, WinInstanceData *instData,
 		selected = FALSE;
 
 		int rowDrawY = drawY;
-
-		rowDrawY += GetGameListRowPixelOffsetForRow(window, i, listLineHeight);
+		ApplyListBoxRowAnimation(window, i, listLineHeight, rowDrawY);
 
 		if (list->multiSelect)
 		{
@@ -682,4 +741,3 @@ void W3DGadgetListBoxImageDraw( GameWindow *window, WinInstanceData *instData )
 
 
 }
-


### PR DESCRIPTION
Refactors and fixes the listbox row entry animation that was added in 239

fixes:
- Animation was frame rate dependent. Now uses timeGetTime() for delta time so behaviour is consistent at any frame rate.
- Listboxes that store pointer based item data did not animate due to unreliable key generation. Now we use the window ID for the animation state key.
- Listboxes such as the communicator and map select only animated on the first open or two. Fixed by resetting a row's animation state when it hasn't been drawn for over 60ms, indicating the listbox was closed.

The original implementation lived in LobbyUtils.cpp where it was mainly added for the game lobby list. This change properly moves all animation logic into ListBox.cpp

