### PR TITLE
fix(gameclient): Fix particle effects not freezing on game pause under GENERALS_ONLINE_HIGH_FPS_RENDER

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GameClient.cpp
@@ -786,7 +786,11 @@ void GameClient::update()
 
 #if defined(GENERALS_ONLINE_HIGH_FPS_RENDER)
 	int64_t currTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::utc_clock::now().time_since_epoch()).count();
-	m_legacyFrameMSAccured += currTime - m_LegacyFrameEndLastFrame;
+
+	if (!freezeTime)
+	{
+		m_legacyFrameMSAccured += currTime - m_LegacyFrameEndLastFrame;
+	}
 	m_LegacyFrameEndLastFrame = currTime;
 
 	// TODO_NGMP: This should really use partial frame intervals instead of a fixed 60hz update


### PR DESCRIPTION
Fixes particle effects and drawable updates continuing to play and fade out when the game is paused

The legacy frame accumulator was advancing regardless of whether the game is paused. This causes any render side system keyed off m_frameLegacy to think time is still progressing during pause, resulting in effects ticking forward / fading out instead of freezing in place.

added a !freezeTime guard to the legacy frame accumulation so that the frame counter stops advancing when the game is paused.

BEFORE
https://github.com/user-attachments/assets/16e931ca-178c-4dc0-b807-4a039e0e61cf

AFTER
https://github.com/user-attachments/assets/da86b7b5-fc6e-4e0b-8039-456b7e27e425



