### PR TITLE
bugfix: Fix game freezing on transition and disconnecting when alt tabbed on game start

### DIFF
--- a/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32GameEngine.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/Win32Device/Common/Win32GameEngine.cpp
@@ -114,7 +114,9 @@ void Win32GameEngine::update()
 			// If we are running a multiplayer game, keep running the logic.
 			// There is code in the client to skip client redraw if we are
 			// iconic.  jba.
-			if (TheGameEngine->getQuitting() || TheGameLogic->isInInternetGame() || TheGameLogic->isInLanGame()) {
+			// GO_CHANGE: If we have an active network session, keep running to prevent disconnecting us from
+			// other players during lobby and loading screen where isInMultiplayerGame() returns false
+			if (TheGameEngine->getQuitting() || TheGameLogic->isInMultiplayerGame() || (TheNetwork != nullptr)) {
 				break; // keep running.
 			}
 		}


### PR DESCRIPTION
When a player alt tabs out on exclusive fullscreen while in lobby and the host starts the game, the main loop sleeps and never resumes. The existing break condition only checks isInMultiplayerGame() which returns false until the game simulation has started. This means MSG_NEW_GAME is never processed for us when the host starts the game while we are tabbed out, leaving the player frozen on the loading screen and appearing disconnected to other players.

The fix checks TheNetwork in the break condition, which is created the moment the host starts the game, allowing the sleep loop to break out and MSG_NEW_GAME to be processed

This also prevents an ELO exploit in quickmatch where a player could deliberately alt tab during matchmaking to appear disconnected, forcing other players into the disconnect screen and gaining ELO points
