### PR TITLE
feat(optionsmenu): Mask IP address display in Options Menu

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/OptionsMenu.cpp
@@ -1106,6 +1106,12 @@ void OptionsMenuInit( WindowLayout *layout, void *userData )
 		}
 	}
 
+	if (comboBoxLANIP)
+		GadgetComboBoxSetText(comboBoxLANIP, L"***.***.***.***");
+
+	if (comboBoxOnlineIP)
+		GadgetComboBoxSetText(comboBoxOnlineIP, L"***.***.***.***");
+
 	// HTTP Proxy
 	GameWindow *textEntryHTTPProxy = TheWindowManager->winGetWindowFromId(nullptr, NAMEKEY("OptionsMenu.wnd:TextEntryHTTPProxy"));
 	if (textEntryHTTPProxy)


### PR DESCRIPTION
Masks the LAN and Online IP address combo boxes in the Options Menu with `***.***.***.***`
The selected IP data is unaffected and saves correctly on Accept.

<img width="1171" height="118" alt="image" src="https://github.com/user-attachments/assets/dd6bf3bc-d387-4526-9560-c0de9ac8d199" />
