### PR TITLE
fix: Preserve host selected slot state after kicking a player

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLGameSetupMenu.cpp
@@ -3868,12 +3868,8 @@ WindowMsgHandledType WOLGameSetupMenuSystem( GameWindow *window, UnsignedInt msg
 								NGMPGameSlot* pSlot = (NGMPGameSlot*)myGame->getSlot(i);
 								int64_t userBeingKicked = pSlot->m_userID;
 
-								NGMP_OnlineServices_LobbyInterface* pLobbyInterface = NGMP_OnlineServicesManager::GetInterface<NGMP_OnlineServices_LobbyInterface>();
-								if (pLobbyInterface != nullptr)
-								{
-									pLobbyInterface->UpdateCurrentLobby_KickUser(userBeingKicked, name);
-								}
-
+								pLobbyInterface->UpdateCurrentLobby_KickUser(userBeingKicked, name);
+								pLobbyInterface->UpdateCurrentLobby_SetSlotState(i, SlotState(pos));  // use what host selected
 								myGame->getSlot(i)->setState(SlotState(pos));
 								myGame->resetAccepted();
 


### PR DESCRIPTION
Fixes a bug where kicking a player from the lobby by closing the slot would not preserve the host selected slot state (remained open).
The selected state is now passed directly to the service and applied locally.

Also removes a redundant null check and redeclaration of pLobbyInterface, we use the one already validated in the outer scope.