### PR TITLE
fix: Render entire terrain on GeneralsOnline extended zoom (water plane bleeds through on large maps)

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/GlobalData.cpp
@@ -832,7 +832,19 @@ GlobalData::GlobalData()
 	m_getHealedAnimationName.clear();
 	m_specialPowerViewObjectName.clear();
 
+#if defined(GENERALS_ONLINE_TEMP_FIX_DRAW_ENTIRE_TERRAIN)
+	// TheSuperHackers/GeneralsOnline @bugfix: Force full-terrain rendering.
+	// The "DrawEntireTerrain" INI field is intentionally not parsed in GeneralsOnline builds, so it
+	// stays out of the INI CRC and all players remain retail-compatible/consistent. However,
+	// GeneralsOnline also enables a non-retail extended camera zoom. With the default partial draw
+	// window, zooming out on a map larger than that window leaves the rest of the terrain undrawn and
+	// exposes the global water plane, so the map looks flooded even when it contains no water.
+	// Forcing the value on restores full-map rendering. This is a client-side visual setting only:
+	// it does not affect the simulation or the INI CRC.
+	m_drawEntireTerrain = TRUE;
+#else
 	m_drawEntireTerrain = FALSE;
+#endif
 	m_maxParticleCount = 0;
 	m_maxFieldParticleCount = 30;
 


### PR DESCRIPTION
## Summary

On GeneralsOnline builds, larger maps render as mostly **water** when the camera is zoomed out, even on maps that contain **no water at all**. Only a fixed-size window of terrain around the camera focus is drawn; everything beyond it falls back to the global water plane. This reproduces on a **stock install with no INI modifications**.

## Repro

- Stock GeneralsOnline 60 Hz client (`GENERALS_ONLINE_VERSION_STRING "060526_QFE2"`).
- Load a large map and zoom the camera out toward maximum.

Result on a stock / vanilla INI install - terrain beyond the draw window is not rendered and the global water plane shows through:

![Vanilla install, zoomed out: terrain window surrounded by water](https://raw.githubusercontent.com/sailro/GameClient/media-water-plane-bug/water-vanilla-highzoom.png)

The smaller the draw window, the worse it is. With `StretchTerrain = Yes` (a 65-tile window) it collapses to a tiny island:

![StretchTerrain shrinks the window further](https://raw.githubusercontent.com/sailro/GameClient/media-water-plane-bug/water-customini-highzoom.png)

## Root cause

`m_drawEntireTerrain` decides whether the whole heightmap is drawn or only a fixed window centered on the camera:

- `WorldHeightMap.cpp:475` - default window `NORMAL_DRAW_WIDTH = 1 + 4*VERTEX_BUFFER_TILE_LENGTH` = **129 tiles** (`VERTEX_BUFFER_TILE_LENGTH = 32`, `WorldHeightMap.h:45`, `:124`).
- `WorldHeightMap.cpp:532-534` and `createDrawArea` (`:2214-2217`) - when `m_drawEntireTerrain` is set, the draw area is expanded to the full map (`m_width` / `m_height`).
- `W3DView.cpp:776` - the camera far-clip plane is aligned to the same size.

In retail this defaults to `FALSE`, and the only way to enable it was the `DrawEntireTerrain` GameData INI key. Retail's limited camera zoom never zoomed far enough to reveal the gap, so it was never visible.

GeneralsOnline adds **non-retail extended camera zoom** (lobby `max_cam_height` up to `GENERALS_ONLINE_MAX_LOBBY_CAMERA_ZOOM` = 1000). Commit 66949422 ("Temp fix for draw entire terrain") then added `GENERALS_ONLINE_TEMP_FIX_DRAW_ENTIRE_TERRAIN`, which:

- removes the `DrawEntireTerrain` field from the INI parse table (`GlobalData.cpp:97-99`), and
- leaves `m_drawEntireTerrain` at its `FALSE` default (`GlobalData.cpp:835`).

So at extended zoom the 129-tile window no longer fills the screen and the water plane fills the rest. Players cannot work around it either: the INI field no longer exists, and a loose INI override would change the INI CRC (sent to the service as `ini_crc`; a mismatch returns `417 Anticheat mismatch`, `OnlineServices_LobbyInterface.cpp:1188`), so it is not viable for online play.

## Proposed fix

Force `m_drawEntireTerrain = TRUE` under the macro. It stays out of the INI parse table, so the INI CRC is unchanged and every player remains consistent / retail-compatible, but the full map is rendered at any zoom.

```cpp
#if defined(GENERALS_ONLINE_TEMP_FIX_DRAW_ENTIRE_TERRAIN)
    m_drawEntireTerrain = TRUE;
#else
    m_drawEntireTerrain = FALSE;
#endif
```

This is a client-side visual setting only - no effect on the simulation or the INI CRC.

## @x64-dev - context and a question

You introduced `GENERALS_ONLINE_TEMP_FIX_DRAW_ENTIRE_TERRAIN` in 66949422 while fixing the metaevent merge (TheSuperHackers/GeneralsGameCode#2577). Since it is labelled a *temp fix*, could you confirm what it was guarding against?

- If it was only to keep `DrawEntireTerrain` out of the INI/CRC for player consistency, then forcing it `TRUE` (above) preserves that and fixes the rendering.
- If `DrawEntireTerrain = TRUE` itself caused a problem at 60 Hz / extended zoom (perf or a crash), then the better fix is to scale the terrain draw window to the camera frustum so only zoomed-out views pay the cost, instead of always drawing the whole map. Glad to take it in that direction with your input.

## Tradeoffs

- Drawing the entire terrain has a per-frame cost on very large maps (the same tradeoff retail players accepted with `DrawEntireTerrain = Yes`). A camera-scaled draw window would be the more refined fix; this PR is the minimal one.

## Testing and disclosure

- Repro confirmed on a live stock install (the vanilla screenshot above).
- The change is a one-line value flip guarded by the existing macro (type-safe by inspection). I have not completed a full local engine build yet, and would value maintainer validation of perf/visuals on large maps.
- Diagnosis and patch were produced with AI assistance (GitHub Copilot CLI) and reviewed by me, per `CONTRIBUTING.md`.

## References

- Regression: 66949422 ("Temp fix for draw entire terrain")
- `NextGenMP_defines.h:14`; `GlobalData.cpp:97-99`, `:835`; `WorldHeightMap.cpp:475`, `:532-534`, `:2214-2217`; `WorldHeightMap.h:45`, `:124`; `W3DView.cpp:776`; `OnlineServices_LobbyInterface.cpp:1188`
