### PR TITLE
fix: Restore obs overlay and notification keymapping and fix f9 toggling after merge

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/Common/Recorder.cpp
@@ -1204,7 +1204,7 @@ Bool RecorderClass::playbackFile(AsciiString filename)
 
     Bool isMultiplayer = (m_originalGameMode == GAME_INTERNET || m_originalGameMode == GAME_LAN);
     m_crcInfo = CRCInfo(header.localPlayerIndex, isMultiplayer);
-    DEBUG_LOG(("Player index is %d, replay CRC interval is %d, isMultiplayer is %d", m_crcInfo->getLocalPlayer(), REPLAY_CRC_INTERVAL, isMultiplayer));
+    DEBUG_LOG(("Player index is %d, replay CRC interval is %d, isMultiplayer is %d", m_crcInfo.getLocalPlayer(), REPLAY_CRC_INTERVAL, isMultiplayer));
 
     DEBUG_LOG(("RecorderClass::playbackFile() - original game was mode %d", m_originalGameMode));
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -2291,6 +2291,7 @@ void InGameUI::reset()
 
 	m_windowLayouts.clear();
 
+	m_observerStatsHidden = false;
 	m_observerNotifications.clear();
 	m_observerMilestones.clear();
 

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/CommandXlat.cpp
@@ -3500,6 +3500,7 @@ GameMessageDisposition CommandTranslator::translateGameMessage(const GameMessage
 			}
 
 			ToggleControlBar();
+			TheInGameUI->toggleObserverStats();
 		}
 		disp = DESTROY_MESSAGE;
 		break;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/MessageStream/MetaEvent.cpp
@@ -809,6 +809,48 @@ void MetaMap::generateMetaMap()
 	// but is not recommended, because it will cause key mapping conflicts with original game languages.
 
 	{
+		MetaMapRec* map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_INCREASE_OBSERVER_NOTIFICATION_FONT);
+		if (map->m_key == MK_NONE)
+		{
+			map->m_key = MK_RIGHT;
+			map->m_transition = DOWN;
+			map->m_modState = SHIFT;
+			map->m_usableIn = COMMANDUSABLE_GAME;
+		}
+	}
+	{
+		MetaMapRec* map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_DECREASE_OBSERVER_NOTIFICATION_FONT);
+		if (map->m_key == MK_NONE)
+		{
+			map->m_key = MK_LEFT;
+			map->m_transition = DOWN;
+			map->m_modState = SHIFT;
+			map->m_usableIn = COMMANDUSABLE_GAME;
+		}
+	}
+
+	{
+		MetaMapRec* map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_INCREASE_OBSERVER_STATS_FONT);
+		if (map->m_key == MK_NONE)
+		{
+			map->m_key = MK_UP;
+			map->m_transition = DOWN;
+			map->m_modState = SHIFT;
+			map->m_usableIn = COMMANDUSABLE_GAME;
+		}
+	}
+	{
+
+		MetaMapRec* map = TheMetaMap->getMetaMapRec(GameMessage::MSG_META_DECREASE_OBSERVER_STATS_FONT);
+		if (map->m_key == MK_NONE)
+		{
+			map->m_key = MK_DOWN;
+			map->m_transition = DOWN;
+			map->m_modState = SHIFT;
+			map->m_usableIn = COMMANDUSABLE_GAME;
+		}
+	}
+	{
 		// Is useful for Generals and Zero Hour.
 		MetaMapRec *map = getMetaMapRec(GameMessage::MSG_META_INCREASE_MAX_RENDER_FPS);
 		if (map->m_key == MK_NONE)


### PR DESCRIPTION
Restores keymapping for the obs and notification overlays and fixes the toggling of the overlay with f9 after latest SH merge