### PR TITLE
bugfix: Clamp zoom to prevent incorrect camera height when using bookmarks

### DIFF
--- a/Core/GameEngine/Include/GameClient/View.h
+++ b/Core/GameEngine/Include/GameClient/View.h
@@ -377,7 +377,7 @@ public:
 		m_pos = pos;
 		m_angle = angle;
 		m_pitch = pitch;
-		m_zoom = zoom;
+		m_zoom = std::clamp(zoom, 0.f, 1.f);
 	}
 
 private:


### PR DESCRIPTION
Fixes a bug where bookmarked views would allow players to go above the allowed maxCameraHeight