### PR TITLE
tweak(ingameui): Simplify network latency display and remove Gentool frames

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -7021,7 +7021,7 @@ void InGameUI::drawNetworkLatency(Int & x, Int & y)
 
 		if (actualFrames != gentoolFrames)
 		{
-			latencyStr.format(L"%u [%ums|%u][L: %u]", gentoolFrames, actualLatencyInMS, actualFrames, TheNetwork->getFrameRate());
+			latencyStr.format(L"[%u] - [%ums - %u]", TheNetwork->getFrameRate(), actualLatencyInMS, actualFrames);
 		}
 		else
 		{


### PR DESCRIPTION
Before 
<img width="181" height="34" alt="image" src="https://github.com/user-attachments/assets/bbb0915a-dd4d-4800-a6e8-4c5730061f45" />

After 
<img width="206" height="62" alt="image" src="https://github.com/user-attachments/assets/a7e207a9-ceea-4cfd-9aa2-fbc6e789b6f9" />
