### PR TITLE
fix: Fix stack overflow in updateMapHoverPreview due to double wrap on menu re entry

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -1451,6 +1451,13 @@ void WOLQuickMatchMenuShutdown( WindowLayout *layout, void *userData )
 	if (!TheGameEngine->getQuitting())
 		saveQuickMatchOptions();
 
+	if (listboxMapSelect && mapListboxPreviewFunc)
+		listboxMapSelect->winSetDrawFunc(mapListboxPreviewFunc);
+
+	mapListboxPreviewFunc = nullptr;
+	mapHoverPreview = nullptr;
+	listboxMapSelect = nullptr;
+
 	parentWOLQuickMatch = nullptr;
 	buttonBack = nullptr;
 	quickmatchTextWindow = nullptr;


### PR DESCRIPTION
Fixes a crash where re entering the quick match menu caused `updateMapHoverPreview` to be saved as its own draw func callback, leading to infinite recursion and a stack overflow.

The fix restores the original draw func and nulls all related statics in Shutdown before clearing listboxMapSelect.