### PR TITLE
fix(stats): Pass resolved side in game outcome payload

### DIFF
--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/OnlineServices_StatsInterface.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/OnlineServices_StatsInterface.cpp
@@ -437,6 +437,18 @@ void NGMP_OnlineServices_StatsInterface::CommitMyOutcome(ScoreKeeper* pScoreKeep
 
 		uint64_t currentMatchID = pLobbyInterface->GetCurrentMatchID();
 
+		int resolvedSide = -1;
+		NGMPGame* myGame = pLobbyInterface->GetCurrentGame();
+
+		    if (myGame != nullptr)
+			{
+				GameSlot* pLocalSlot = myGame->getSlot(myGame->getLocalSlotNum());
+				if (pLocalSlot != nullptr)
+				{
+					resolvedSide = pLocalSlot->getPlayerTemplate();
+				}
+            }
+
 		nlohmann::json j;
 		j["buildings_built"] = buildingsBuilt;
 		j["buildings_killed"] = buildingsDestroyed;
@@ -447,6 +459,7 @@ void NGMP_OnlineServices_StatsInterface::CommitMyOutcome(ScoreKeeper* pScoreKeep
 		j["total_money"] = totalMoney;
 		j["won"] = bWon;
 		j["match_id"] = currentMatchID;
+		j["side"] = resolvedSide;
 
 		std::string strPostData = j.dump();
 	


### PR DESCRIPTION
By the end of the match, the game slot's `PlayerTemplate` has been updated from `PLAYERTEMPLATE_RANDOM` to the actual resolved faction.

This change reads the resolved side from the game slot at the end of the match and includes it in the outcome payload, allowing the Service to update the placeholder match history with the resolved faction.

Merge alongside https://github.com/GeneralsOnlineDevelopmentTeam/Services/pull/22 (`fix(stats): report correctly resolved side instead of random in custom matches`).

