### PR TITLE
fix: Correct avgFPS reporting in the network stats overlay 

### DIFF
--- a/Core/GameEngine/Source/GameNetwork/FrameMetrics.cpp
+++ b/Core/GameEngine/Source/GameNetwork/FrameMetrics.cpp
@@ -84,7 +84,11 @@ FrameMetrics::~FrameMetrics() {
 }
 
 void FrameMetrics::init() {
+#if defined(GENERALS_ONLINE_HIGH_FPS_SERVER)
+	m_averageFps = GENERALS_ONLINE_HIGH_FPS_LIMIT;
+#else
 	m_averageFps = 30;
+#endif
 
 #if defined(GENERALS_ONLINE)
 	// NGMP_NOTE: Don't start with the assumption that we have latency. Connections are now formed earlier, so we have latency data earlier too.
@@ -113,7 +117,11 @@ void FrameMetrics::init() {
 
 	UnsignedInt i = 0;
 	for (; i < TheGlobalData->m_networkFPSHistoryLength; ++i) {
+#if defined(GENERALS_ONLINE_HIGH_FPS_SERVER)
+		m_fpsList[i] = GENERALS_ONLINE_HIGH_FPS_LIMIT;
+#else
 		m_fpsList[i] = 30.0;
+#endif
 	}
 	m_fpsListIndex = 0;
 	for (i = 0; i < TheGlobalData->m_networkLatencyHistoryLength; ++i)

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/InGameUI.cpp
@@ -7231,7 +7231,7 @@ void InGameUI::drawGameTime()
 					m_gameTimeString->getSize(&w, &h);
 
 					bool bIsHighQuality = true;
-					if (avgFPS < GENERALS_ONLINE_HIGH_FPS_LIMIT || status.m_cbSentUnackedReliable >= 1000 || (status.m_flConnectionQualityLocal != -1.f && status.m_flConnectionQualityLocal < 1.f) || (status.m_flConnectionQualityRemote != -1.f && status.m_flConnectionQualityRemote < 1.f))
+					if (avgFPS < (GENERALS_ONLINE_HIGH_FPS_LIMIT - 1) || status.m_cbSentUnackedReliable >= 1000 || (status.m_flConnectionQualityLocal != -1.f && status.m_flConnectionQualityLocal < 1.f) || (status.m_flConnectionQualityRemote != -1.f && status.m_flConnectionQualityRemote < 1.f))
 					{
 						bIsHighQuality = false;
 					}


### PR DESCRIPTION
Fixes an issue where the FPS reported in the network stats overlay was offset by +30 due to the FPS baseline being initialized to 30 instead of 60.
With the correct baseline, the overlay can now show 59 FPS for players capped at 60, which would incorrectly trigger badColor/red for them, to avoid this, the threshold check is relaxed by 1 FPS.
<img width="92" height="52" alt="image" src="https://github.com/user-attachments/assets/4fdbd82a-f400-4961-92c5-db4993075b65" />
