### PR TITLE
feat(quickmatch): Add minimum maps selection in quickmatch from playlist data

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameNetwork/GeneralsOnline/OnlineServices_MatchmakingInterface.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameNetwork/GeneralsOnline/OnlineServices_MatchmakingInterface.h
@@ -15,6 +15,7 @@ struct PlaylistEntry
 	std::string Name = std::string();
 	int MinPlayers = -1;
 	int DesiredPlayers = -1;
+	int MinSelectedMaps = 0;
 	bool AllowTeams = false;
 	int TeamSize = -1;
 	bool AllowArmySelection = false;

--- a/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameClient/GUI/GUICallbacks/Menus/WOLQuickMatchMenu.cpp
@@ -2218,6 +2218,7 @@ WindowMsgHandledType WOLQuickMatchMenuSystem( GameWindow *window, UnsignedInt ms
 
 					std::vector<int> vecSelectedMapIndexes;
 					uint16_t playlistID = 0;
+					int minSelectedMaps = 0;
 
 					// get maps and playlist ID
 					std::list<AsciiString> maps;
@@ -2233,6 +2234,7 @@ WindowMsgHandledType WOLQuickMatchMenuSystem( GameWindow *window, UnsignedInt ms
 							if (plEntry.PlaylistID != -1)
 							{
 								playlistID = plEntry.PlaylistID;
+								minSelectedMaps = plEntry.MinSelectedMaps;
 
 								// maps
 								Int numMaps = GadgetListBoxGetNumEntries(listboxMapSelect);
@@ -2254,6 +2256,22 @@ WindowMsgHandledType WOLQuickMatchMenuSystem( GameWindow *window, UnsignedInt ms
 					else
 					{
 						// TODO_QUICKMATCH: Error?
+					}
+					
+					if (static_cast<int>(vecSelectedMapIndexes.size()) < minSelectedMaps)
+					{
+						UnicodeString msg;
+						msg.format(L"You must select at least %d maps.", minSelectedMaps);
+						Int index = GadgetListBoxAddEntryText(quickmatchTextWindow, msg, GameSpyColor[GSCOLOR_DEFAULT], -1, -1);
+						GadgetListBoxSetItemData(quickmatchTextWindow, (void*)-1, index);
+						
+						// buttons
+						buttonWiden->winEnable(FALSE);
+						buttonStart->winHide(FALSE);
+						buttonStart->winEnable(TRUE);
+						buttonStop->winHide(TRUE);
+						
+						break;
 					}
 
 					// buttons

--- a/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/OnlineServices_MatchmakingInterface.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameNetwork/GeneralsOnline/OnlineServices_MatchmakingInterface.cpp
@@ -28,6 +28,7 @@ void NGMP_OnlineServices_MatchmakingInterface::RetrievePlaylists(std::function<v
 					playlistEntryIter["Name"].get_to(playlistEntry.Name);
 					playlistEntryIter["MinPlayers"].get_to(playlistEntry.MinPlayers);
 					playlistEntryIter["DesiredPlayers"].get_to(playlistEntry.DesiredPlayers);
+					playlistEntryIter["MinSelectedMaps"].get_to(playlistEntry.MinSelectedMaps);
 					playlistEntryIter["AllowTeams"].get_to(playlistEntry.AllowTeams);
 					playlistEntryIter["TeamSize"].get_to(playlistEntry.TeamSize);
 					playlistEntryIter["AllowArmySelection"].get_to(playlistEntry.AllowArmySelection);


### PR DESCRIPTION
This change implements a minimum map selection count in Quickmatch.  To start matchmaking, number of maps selected would need to be >= `MinSelectedMaps`. This is as discussed with x64 in preparation for the World Series. To ensure no behavioral change, both Playlists have `MinSelectedMaps` configured to 1 right now.

Merge alongside the corresponding https://github.com/GeneralsOnlineDevelopmentTeam/Services/pull/23 PR